### PR TITLE
Added article search

### DIFF
--- a/app/src/main/kotlin/org/avisen/app/App.kt
+++ b/app/src/main/kotlin/org/avisen/app/App.kt
@@ -226,6 +226,20 @@ fun Application.module() {
                     call.respond(HttpStatusCode.OK, subchain)
                 }
 
+                route("/article/{articleId}") {
+                    get {
+                        val id = call.parameters["articleId"]!!
+
+                        val article = blockchain.getArticle(id)
+
+                        if (article != null) {
+                            call.respond(HttpStatusCode.OK, article)
+                        } else {
+                            call.response.status(HttpStatusCode.NotFound)
+                        }
+                    }
+                }
+
                 route("/block") {
                     post {
                         val newBlock = call.receive<Block>()

--- a/app/src/main/resources/openapi/documentation.yml
+++ b/app/src/main/resources/openapi/documentation.yml
@@ -92,6 +92,28 @@ paths:
                   $ref: '#/components/schemas/Block'
         "404":
           description: Not found
+  /blockchain/article/{id}:
+    get:
+      summary: Get a specific article
+      description: Searches the entire blockchain for a specific article or an error if it does not exist.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: ef2fd456eb5ea817ad180ce1d29f79e82a999609bfb9027108f76416118c47e2
+      responses:
+        "200":
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Article'
+        "404":
+          description: Not found
 
   /network:
     get:
@@ -188,6 +210,27 @@ components:
         height:
           type: integer
           format: int64
+
+    Article:
+      type: object
+      properties:
+        id:
+          type: string
+        byline:
+          type: string
+        headline:
+          type: string
+        section:
+          type: string
+        content:
+          type: string
+        date:
+          type: string
+          format: date
+        publisherKey:
+          type: string
+        signature:
+          type: string
 
     KeyPairString:
       type: object

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -186,14 +186,14 @@ class BlockchainTest : DescribeSpec({
 
             genesisBlock.previousHash.shouldBeEmpty()
             genesisBlock.height shouldBe 0u
-            genesisBlock.data shouldBe "Genesis"
+            genesisBlock.data shouldBe TransactionData(emptyList())
         }
     }
 })
 
 fun randomBlock(previousHash: String, height: UInt, timestamp: Long = Instant.now().toEpochMilli()) = Block(
     previousHash = previousHash,
-    data = "test",
+    data = TransactionData(emptyList()),
     timestamp = timestamp,
     height = height,
 )

--- a/docs/index.html
+++ b/docs/index.html
@@ -689,6 +689,20 @@
   <script>
     // Script section to load models into a JS Var
     var defs = {}
+            defs["Article"] = {
+  "properties" : {
+    "id" : { },
+    "byline" : { },
+    "headline" : { },
+    "section" : { },
+    "content" : { },
+    "date" : {
+      "format" : "date"
+    },
+    "publisherKey" : { },
+    "signature" : { }
+  }
+};
             defs["Block"] = {
   "properties" : {
     "hash" : { },
@@ -744,6 +758,9 @@
             <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
 
                   <li class="nav-header" data-group="Default"><a href="#api-Default">API Methods - Default</a></li>
+                    <li data-group="Default" data-name="blockchainArticleIdGet" class="">
+                      <a href="#api-Default-blockchainArticleIdGet">blockchainArticleIdGet</a>
+                    </li>
                     <li data-group="Default" data-name="blockchainBlockHashGet" class="">
                       <a href="#api-Default-blockchainBlockHashGet">blockchainBlockHashGet</a>
                     </li>
@@ -789,6 +806,301 @@
         <div id="sections">
                 <section id="api-Default">
                   <h1>Default</h1>
+                    <div id="api-Default-blockchainArticleIdGet">
+                      <article id="api-Default-blockchainArticleIdGet-0" data-group="User" data-name="blockchainArticleIdGet" data-version="0">
+                        <div class="pull-left">
+                          <h1>blockchainArticleIdGet</h1>
+                          <p>Get a specific article</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Searches the entire blockchain for a specific article or an error if it does not exist.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/blockchain/article/{id}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-blockchainArticleIdGet-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-blockchainArticleIdGet-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-blockchainArticleIdGet-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-blockchainArticleIdGet-0-python">Python</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-blockchainArticleIdGet-0-curl">
+                           <pre class="prettyprint"><code class="language-bsh">curl -X GET\
+-H "Accept: application/json"\
+"//blockchain/article/{id}"</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-java">
+                            <pre class="prettyprint"><code class="language-java">import io.swagger.client.*;
+import io.swagger.client.auth.*;
+import io.swagger.client.model.*;
+import io.swagger.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+
+    public static void main(String[] args) {
+        
+        DefaultApi apiInstance = new DefaultApi();
+         id = ; //  | 
+        try {
+            apiInstance.blockchainArticleIdGet(id);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#blockchainArticleIdGet");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-android">
+                            <pre class="prettyprint"><code class="language-java">import io.swagger.client.api.DefaultApi;
+
+public class DefaultApiExample {
+
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+         id = ; //  | 
+        try {
+            apiInstance.blockchainArticleIdGet(id);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#blockchainArticleIdGet");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp"> *id = ; // 
+
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+
+// Get a specific article
+[apiInstance blockchainArticleIdGetWith:id
+              completionHandler: ^(NSError* error) {
+                            if (error) {
+                                NSLog(@"Error: %@", error);
+                            }
+                        }];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var Avisen = require('avisen');
+
+var api = new Avisen.DefaultApi()
+var id = ; // {{}} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.blockchainArticleIdGet(id, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class blockchainArticleIdGetExample
+    {
+        public void main()
+        {
+
+            var apiInstance = new DefaultApi();
+            var id = new (); //  | 
+
+            try
+            {
+                // Get a specific article
+                apiInstance.blockchainArticleIdGet(id);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling DefaultApi.blockchainArticleIdGet: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+$api_instance = new Swagger\Client\ApiDefaultApi();
+$id = ; //  | 
+
+try {
+    $api_instance->blockchainArticleIdGet($id);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->blockchainArticleIdGet: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::SwaggerClient::Configuration;
+use WWW::SwaggerClient::DefaultApi;
+
+my $api_instance = WWW::SwaggerClient::DefaultApi->new();
+my $id = ; #  | 
+
+eval { 
+    $api_instance->blockchainArticleIdGet(id => $id);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->blockchainArticleIdGet: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-blockchainArticleIdGet-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import swagger_client
+from swagger_client.rest import ApiException
+from pprint import pprint
+
+# create an instance of the API class
+api_instance = swagger_client.DefaultApi()
+id =  #  | 
+
+try: 
+    # Get a specific article
+    api_instance.blockchain_article_id_get(id)
+except ApiException as e:
+    print("Exception when calling DefaultApi->blockchainArticleIdGet: %s\n" % e)</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">id*</td>
+                                  <td>
+                                  
+                                  
+                                      <div id="d2e199_blockchainArticleIdGet_id">
+                                          <div class="json-schema-view">
+                                              <div class="primitive">
+                                                  <span class="type">
+                                                      
+                                                  </span>
+                                  
+                                              </div>
+                                                  <div class="inner required">
+                                                      Required
+                                                  </div>
+                                          </div>
+                                      </div>
+                                  </td>
+                                  </tr>
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - Ok </h3>
+
+                            <ul class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-blockchainArticleIdGet-200-schema">Schema</a>
+                                </li>
+
+                            </ul>
+
+                            <div class="tab-content" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-blockchainArticleIdGet-200-schema">
+                                  <div id='responses-blockchainArticleIdGet-200-schema-200' style="padding: 30px; border-left: 1px solid #eee; border-right: 1px solid #eee; border-bottom: 1px solid #eee;">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "Ok",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "items" : {
+          "$ref" : "#/components/schemas/Article"
+        },
+        "x-content-type" : "application/json"
+      }
+    }
+  }
+};
+                                        var schema = schemaWrapper.content["application/json"].schema;
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else {
+                                          schemaWrapper.components = {};
+                                          schemaWrapper.components.schemas = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        //console.log(JSON.stringify(schema));
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-blockchainArticleIdGet-200-schema-data').val(stringify(schema));
+                                        var result = $('#responses-blockchainArticleIdGet-200-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-blockchainArticleIdGet-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+
+                            <h3> Status: 404 - Not found </h3>
+
+                            <ul class="nav nav-tabs nav-tabs-examples" >
+                            </ul>
+
+                            <div class="tab-content" style='margin-bottom: 10px;'>
+                            </div>
+
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-blockchainBlockHashGet">
                       <article id="api-Default-blockchainBlockHashGet-0" data-group="User" data-name="blockchainBlockHashGet" data-version="0">
                         <div class="pull-left">

--- a/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
+++ b/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import org.avisen.blockchain.Block
+import org.avisen.blockchain.TransactionData
 import java.time.Instant
 
 class NetworkTest: DescribeSpec({
@@ -59,7 +60,7 @@ class NetworkTest: DescribeSpec({
                 network.addPeer(Node("first", NodeType.REPLICA), false)
                 network.addPeer(Node("second", NodeType.REPLICA), false)
 
-                network.broadcastBlock(Block("prevHash", "data", Instant.now().toEpochMilli(), 1u))
+                network.broadcastBlock(Block("prevHash", TransactionData(emptyList()), Instant.now().toEpochMilli(), 1u))
 
                 coVerify(exactly = 2) { networkClient.broadcastBlock(any(), any()) }
             }

--- a/sql/build.gradle.kts
+++ b/sql/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-core:$exposed")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposed")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposed")
+    implementation("org.jetbrains.exposed:exposed-json:$exposed")
     implementation("com.zaxxer:HikariCP:$hikari")
     implementation("org.flywaydb:flyway-core:$flyway")
     implementation("org.flywaydb:flyway-database-postgresql:$flyway")

--- a/sql/src/main/resources/db/migration/V20250222081742__init.sql
+++ b/sql/src/main/resources/db/migration/V20250222081742__init.sql
@@ -2,14 +2,8 @@ CREATE TABLE IF NOT EXISTS block (
     id BIGSERIAL PRIMARY KEY,
     hash VARCHAR(64) NOT NULL,
     previous_hash VARCHAR(64) NOT NULL,
-    data VARCHAR(20000) NOT NULL,
+    data jsonb NOT NULL,
     timestamp BIGINT NOT NULL,
     height BIGINT NOT NULL,
     create_date TIMESTAMP NOT NULL
 );
-
-CREATE TABLE IF NOT EXISTS network_peer (
-    id BIGSERIAL PRIMARY KEY,
-    address VARCHAR(30) NOT NULL,
-    type VARCHAR(12) NOT NULL
-)

--- a/storage/build.gradle.kts
+++ b/storage/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
     implementation("ch.qos.logback:logback-classic:$logback")
 
+    implementation(project((":crypto")))
+
     testImplementation("io.kotest:kotest-runner-junit5:$kotest")
     testImplementation("io.kotest:kotest-assertions-core:$kotest")
     testImplementation("io.mockk:mockk:$mockk")

--- a/storage/src/main/kotlin/org/avisen/storage/Storage.kt
+++ b/storage/src/main/kotlin/org/avisen/storage/Storage.kt
@@ -1,5 +1,6 @@
 package org.avisen.storage
 
+import kotlinx.serialization.Serializable
 import java.time.Instant
 
 interface Storage {
@@ -10,13 +11,31 @@ interface Storage {
     fun chainSize(): Long
     fun blocks(page: Int, size: Int, sort: String?): List<StoreBlock>
     fun blocksFromHeight(height: UInt, page: Int): List<StoreBlock>
+    fun article(id: String): StoreArticle?
 }
 
 data class StoreBlock(
     val hash: String,
     val previousHash: String,
-    val data: String,
+    val data: StoreTransactionData,
     val timestamp: Long,
     val height: UInt,
-    val createDate: Instant = Instant.now()
+    val createDate: Instant = Instant.now(),
+)
+
+@Serializable
+data class StoreTransactionData(
+    val articles: List<StoreArticle>,
+)
+
+@Serializable
+data class StoreArticle (
+    val id: String,
+    val publisherKey: String,
+    val byline: String,
+    val headline: String,
+    val section: String,
+    val content: String,
+    val date: String,
+    val signature: String,
 )


### PR DESCRIPTION
Changes
* Added `id` field to `Article`. It is a hash of the rest of the data minus the signature.
* Changed `Block.data` to be `jsonb` type. Jsonb has many benefits over a raw string or even the `json` column type. Including more efficient storage, better indexing, and faster where clauses.
* `Block.data` is now an object instead of an array of articles, so that it can be expanded on with future changes (publisherPublicKeys, votes, misinformation tracking, etc.)
* Added the first function that searches through a `Block.article`'s data. This one looks for the `id` field.
* Added REST API endpoint to get an article by its id. Further future enhancements include seeing which block it's a member of, etc.
* Removed unused `network_peers` table