### PR TITLE
Save publishers on blockchain

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,17 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="postgres@localhost [2]" uuid="bfc134ee-4f74-45c2-b22c-0a9a3a100a26">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5433/postgres</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+up-db:
+	docker compose up -d
+
+down-db:
+	docker compose down

--- a/app/src/main/kotlin/org/avisen/app/App.kt
+++ b/app/src/main/kotlin/org/avisen/app/App.kt
@@ -168,7 +168,7 @@ fun Application.module() {
                 environment.log.info("No donor node address found. Beginning genesis...")
                 networkId = UUID.randomUUID().toString()
 
-                blockchain.processBlock(Block.genesis())
+                blockchain.processBlock(Block.genesis(publisherPublicKey!!))
             } else {
                 environment.log.info("No donor node address found. Blockchain already detected.")
             }

--- a/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
+++ b/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
@@ -60,7 +60,7 @@ class NetworkTest: DescribeSpec({
                 network.addPeer(Node("first", NodeType.REPLICA), false)
                 network.addPeer(Node("second", NodeType.REPLICA), false)
 
-                network.broadcastBlock(Block("prevHash", TransactionData(emptyList()), Instant.now().toEpochMilli(), 1u))
+                network.broadcastBlock(Block("prevHash", TransactionData(emptyList(), emptySet()), Instant.now().toEpochMilli(), 1u))
 
                 coVerify(exactly = 2) { networkClient.broadcastBlock(any(), any()) }
             }

--- a/sql/src/main/kotlin/org/avisen/sql/Db.kt
+++ b/sql/src/main/kotlin/org/avisen/sql/Db.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.javatime.timestamp
 import org.jetbrains.exposed.sql.json.contains
-import org.jetbrains.exposed.sql.json.extract
 import org.jetbrains.exposed.sql.json.jsonb
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/storage/src/main/kotlin/org/avisen/storage/Storage.kt
+++ b/storage/src/main/kotlin/org/avisen/storage/Storage.kt
@@ -26,6 +26,7 @@ data class StoreBlock(
 @Serializable
 data class StoreTransactionData(
     val articles: List<StoreArticle>,
+    val publishers: Set<String>,
 )
 
 @Serializable


### PR DESCRIPTION
Changes
* Added makefile with shortcuts to bring the dbs up and down
* Store publishers on the blockchain:
![Screenshot 2025-02-27 at 4 37 57 PM](https://github.com/user-attachments/assets/f69b342b-0abd-4000-8542-54a7f6f76232)
* When publishers are added, they are added to the list and the list is re-minted in the new block
* Fixed bug where articles were not being broadcast properly
