### PR TITLE
Added signing of blocks

### DIFF
--- a/.idea/runConfigurations/App_1.xml
+++ b/.idea/runConfigurations/App_1.xml
@@ -6,12 +6,12 @@
       <env name="DB_PASS" value="password" />
       <env name="DB_URL" value="jdbc:postgresql://localhost:5432/postgres" />
       <env name="DB_USER" value="postgres" />
+      <env name="NETWORK_ID" value="local" />
       <env name="NODE_ADDRESS" value="http://localhost:8081" />
       <env name="NODE_MODE" value="PUBLISHER" />
       <env name="PORT" value="8081" />
       <env name="PUBLISHER_PUBLIC_KEY" value="MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEje4IzKZB+pqvn5iT9QLgX97HtigQYQ6D5BXVWh8vBfvGPCzDtmSOhsji753dPciU" />
       <env name="PUBLISHER_SIGNING_KEY" value="MHsCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEYTBfAgEBBBitZRQG15sGSSyBKRBZ96XDkx+t03p3P4ugCgYIKoZIzj0DAQGhNAMyAASN7gjMpkH6mq+fmJP1AuBf3se2KBBhDoPkFdVaHy8F+8Y8LMO2ZI6GyOLvnd09yJQ=" />
-      <env name="NETWORK_ID" value="local" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.avisen.app.AppKt" />
     <module name="avisen-kt.app.main" />

--- a/app/src/main/kotlin/org/avisen/app/App.kt
+++ b/app/src/main/kotlin/org/avisen/app/App.kt
@@ -208,6 +208,8 @@ fun Application.module() {
                             val newPublisher = call.receive<Publisher>()
 
                             blockchain.acceptPublisher(newPublisher.publicKey)
+
+                            call.response.status(HttpStatusCode.OK)
                         }
                     }
                 }

--- a/app/src/main/kotlin/org/avisen/app/App.kt
+++ b/app/src/main/kotlin/org/avisen/app/App.kt
@@ -108,7 +108,7 @@ fun Application.module() {
             throw RuntimeException("A Donor is required when starting a node in REPLICA mode.")
         }
 
-        val blockchain = Blockchain(storage(), Pair(publisherSigningKey!!, publisherPublicKey!!))
+        val blockchain = Blockchain(storage(), Pair(publisherSigningKey ?: "", publisherPublicKey ?: ""))
         // If a donor node has been specified,
         // get the blockchain, transactions, and network from it
         if (donorNode != null) {
@@ -168,7 +168,7 @@ fun Application.module() {
                 environment.log.info("No donor node address found. Beginning genesis...")
                 networkId = UUID.randomUUID().toString()
 
-                blockchain.processBlock(Block.genesis(publisherPublicKey, publisherSigningKey))
+                blockchain.processBlock(Block.genesis(publisherPublicKey!!, publisherSigningKey!!))
             } else {
                 environment.log.info("No donor node address found. Blockchain already detected.")
             }

--- a/app/src/main/resources/openapi/documentation.yml
+++ b/app/src/main/resources/openapi/documentation.yml
@@ -152,6 +152,20 @@ paths:
         "201":
           description: Created
 
+  /network/node/publisher:
+    post:
+      summary: Add a publisher
+      description: Adds a publisher to the block's list of unprocessed publishers. Once a block is minted, the publisher can mint its own blocks.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Publisher'
+      responses:
+        "200":
+          description: Ok
+
   /util/crypto/key-pair:
     post:
       summary: Generates a key pair
@@ -252,4 +266,10 @@ components:
       type: object
       properties:
         signature:
+          type: string
+
+    Publisher:
+      type: object
+      properties:
+        publicKey:
           type: string

--- a/blockchain/src/main/kotlin/org/avisen/blockchain/Blockchain.kt
+++ b/blockchain/src/main/kotlin/org/avisen/blockchain/Blockchain.kt
@@ -120,7 +120,7 @@ data class Blockchain(
 
             if (block.timestamp <= latestBlock.timestamp) return false
 
-            if (!block.data.publishers.contains(latestBlock.publisherKey)) return false
+            if (!latestBlock.data.publishers.contains(block.publisherKey)) return false
 
             if (!verifySignature(block.publisherKey.toPublicKey(), block.previousHash + block.data + block.timestamp + block.height, block.signature.hexStringToByteArray())) return false
         }

--- a/blockchain/src/main/kotlin/org/avisen/blockchain/Blockchain.kt
+++ b/blockchain/src/main/kotlin/org/avisen/blockchain/Blockchain.kt
@@ -5,6 +5,9 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import org.avisen.crypto.hash
 import org.avisen.crypto.hexStringToByteArray
+import org.avisen.crypto.sign
+import org.avisen.crypto.toHexString
+import org.avisen.crypto.toPrivateKey
 import org.avisen.crypto.toPublicKey
 import org.avisen.crypto.verifySignature
 import org.avisen.storage.Storage
@@ -18,6 +21,8 @@ import java.time.Instant
  */
 data class Blockchain(
     val storage: Storage,
+    // private, public
+    val publisherKeys: Pair<String, String>,
     private val unprocessedArticles: MutableList<Article> = mutableListOf(),
     private val unprocessedPublishers: MutableSet<String> = mutableSetOf(),
 ) {
@@ -54,7 +59,7 @@ data class Blockchain(
     fun processArticle(article: Article): ProcessedArticle {
         // First verify the Article's signature
         val verified = verifySignature(
-            article.publisherKey.toPublicKey(),
+            article.authorKey.toPublicKey(),
             article.byline + article.headline + article.section + article.content + article.date,
             article.signature.hexStringToByteArray()
         )
@@ -72,9 +77,13 @@ data class Blockchain(
             val latestBlock = storage.latestBlock()
             val previousHash = latestBlock!!.hash
 
+            val data = TransactionData(unprocessedArticles.toList(), processPublishers(latestBlock.data.publishers))
+            val newHeight = latestBlock.height + 1u
             val newBlock = Block(
+                publisherKeys.second,
+                sign(publisherKeys.first.toPrivateKey(), previousHash + data + timestamp + newHeight).toHexString(),
                 previousHash,
-                TransactionData(unprocessedArticles.toList(), processPublishers(latestBlock.data.publishers)),
+                data,
                 timestamp,
                 latestBlock.height + 1u
             )
@@ -110,6 +119,10 @@ data class Blockchain(
             if (block.previousHash != latestBlock.hash) return false
 
             if (block.timestamp <= latestBlock.timestamp) return false
+
+            if (!block.data.publishers.contains(latestBlock.publisherKey)) return false
+
+            if (!verifySignature(block.publisherKey.toPublicKey(), block.previousHash + block.data + block.timestamp + block.height, block.signature.hexStringToByteArray())) return false
         }
 
         storage.storeBlock(block.toStore())
@@ -119,6 +132,8 @@ data class Blockchain(
 
 @Serializable
 data class Block(
+    val publisherKey: String,
+    val signature: String,
     val previousHash: String,
     // Data represents articles that have been minted into a json string
     val data: TransactionData,
@@ -127,12 +142,17 @@ data class Block(
     @OptIn(ExperimentalSerializationApi::class) @EncodeDefault val hash: String = hash(previousHash + timestamp + data),
 ) {
     companion object {
-        fun genesis(genesisPublisher: String = ""): Block {
+        fun genesis(genesisPublisherKey: String = "", genesisSigningKey: String = ""): Block {
+            val data = TransactionData(listOf(), setOf(genesisPublisherKey))
+            val timestamp = Instant.now().toEpochMilli()
+            val height = 0u
             return Block(
+                genesisPublisherKey,
+                sign(genesisSigningKey.toPrivateKey(), "" + data + timestamp + height).toHexString(),
                 "",
-                TransactionData(listOf(), setOf(genesisPublisher)),
-                Instant.now().toEpochMilli(),
-                0u,
+                data,
+                timestamp,
+                height,
             )
         }
     }
@@ -149,7 +169,7 @@ data class Article(
     /**
      * The public key corresponding to the publisher of the article
      */
-    val publisherKey: String,
+    val authorKey: String,
     val byline: String,
     val headline: String,
     /**
@@ -168,7 +188,7 @@ data class Article(
      * The ECDSA signature of the Article (byline + headline + section + content + date)
      */
     val signature: String,
-    @OptIn(ExperimentalSerializationApi::class) @EncodeDefault val id: String = hash(publisherKey + byline + headline + section + content + date),
+    @OptIn(ExperimentalSerializationApi::class) @EncodeDefault val id: String = hash(authorKey + byline + headline + section + content + date),
 ) {
 
 }
@@ -178,8 +198,8 @@ data class ProcessedArticle(
     val block: Block?,
 )
 
-fun Block.toStore() = StoreBlock(hash, previousHash, data.toStoreTransactionData(), timestamp, height)
-fun StoreBlock.toBlock() = Block(previousHash, data.toTransactionData(), timestamp, height, hash)
+fun Block.toStore() = StoreBlock(publisherKey, signature, hash, previousHash, data.toStoreTransactionData(), timestamp, height)
+fun StoreBlock.toBlock() = Block(publisherKey, signature, previousHash, data.toTransactionData(), timestamp, height, hash)
 fun List<StoreBlock>.toBlocks() = map { it.toBlock() }
 fun TransactionData.toStoreTransactionData() = StoreTransactionData(
     articles.map { it.toStoreArticle() },
@@ -189,7 +209,7 @@ fun StoreTransactionData.toTransactionData() = TransactionData(articles.map { it
 
 fun Article.toStoreArticle() = StoreArticle(
     id,
-    publisherKey,
+    authorKey,
     byline,
     headline,
     section,

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -233,7 +233,7 @@ fun randomArticle(publisherKeyPair: Pair<PrivateKey, PublicKey>): Article {
     val signature = sign(publisherKeyPair.first, byline + headline +section + content + date)
 
     return Article(
-        publisherKey = publisherKeyPair.second.getString(),
+        authorKey = publisherKeyPair.second.getString(),
         byline,
         headline,
         section,

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -21,11 +21,11 @@ import java.security.PublicKey
 import java.time.Instant
 import java.time.LocalDate
 
+const val publisherPublicKey = "MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEje4IzKZB+pqvn5iT9QLgX97HtigQYQ6D5BXVWh8vBfvGPCzDtmSOhsji753dPciU"
+const val publisherSigningKey = "MHsCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEYTBfAgEBBBitZRQG15sGSSyBKRBZ96XDkx+t03p3P4ugCgYIKoZIzj0DAQGhNAMyAASN7gjMpkH6mq+fmJP1AuBf3se2KBBhDoPkFdVaHy8F+8Y8LMO2ZI6GyOLvnd09yJQ="
+
 class BlockchainTest : DescribeSpec({
     setupSecurity()
-
-    val publisherPublicKey = "MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEje4IzKZB+pqvn5iT9QLgX97HtigQYQ6D5BXVWh8vBfvGPCzDtmSOhsji753dPciU"
-    val publisherSigningKey = "MHsCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEYTBfAgEBBBitZRQG15sGSSyBKRBZ96XDkx+t03p3P4ugCgYIKoZIzj0DAQGhNAMyAASN7gjMpkH6mq+fmJP1AuBf3se2KBBhDoPkFdVaHy8F+8Y8LMO2ZI6GyOLvnd09yJQ="
 
     describe("Blockchain") {
         describe("getBlock") {
@@ -33,7 +33,7 @@ class BlockchainTest : DescribeSpec({
                 val storage = mockk<Storage>()
                 val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
 
-                val randomBlock = randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val randomBlock = randomBlock("", 1u)
                 every { storage.getBlock(any()) } returns randomBlock.toStore()
 
                 blockchain.getBlock(randomBlock.hash) shouldBe randomBlock
@@ -47,15 +47,15 @@ class BlockchainTest : DescribeSpec({
 
                 every { storage.blocks(any(), any(), any()) } returns listOf(
                     Block.genesis(publisherPublicKey, publisherSigningKey).toStore(),
-                    randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 2u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 3u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 4u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 5u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 6u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 7u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 8u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 9u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 1u).toStore(),
+                    randomBlock("", 2u).toStore(),
+                    randomBlock("", 3u).toStore(),
+                    randomBlock("", 4u).toStore(),
+                    randomBlock("", 5u).toStore(),
+                    randomBlock("", 6u).toStore(),
+                    randomBlock("", 7u).toStore(),
+                    randomBlock("", 8u).toStore(),
+                    randomBlock("", 9u).toStore(),
                 )
 
                 blockchain.chain(0, null, null, null) shouldHaveSize 10
@@ -67,18 +67,18 @@ class BlockchainTest : DescribeSpec({
 
                 every { storage.blocks(0, any(), any()) } returns listOf(
                     Block.genesis(publisherPublicKey, publisherSigningKey).toStore(),
-                    randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 2u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 3u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 4u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 1u).toStore(),
+                    randomBlock("", 2u).toStore(),
+                    randomBlock("", 3u).toStore(),
+                    randomBlock("", 4u).toStore(),
                 )
 
                 every { storage.blocks(1, any(), any()) } returns listOf(
-                    randomBlock("", 5u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 6u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 7u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 8u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
-                    randomBlock("", 9u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 5u).toStore(),
+                    randomBlock("", 6u).toStore(),
+                    randomBlock("", 7u).toStore(),
+                    randomBlock("", 8u).toStore(),
+                    randomBlock("", 9u).toStore(),
                 )
 
                 blockchain.chain(0, 5, null, null) shouldHaveSize 5
@@ -163,8 +163,6 @@ class BlockchainTest : DescribeSpec({
                     TransactionData(
                         emptyList(), setOf(publisherPublicKey)
                     ),
-                    publisherPublicKey,
-                    publisherSigningKey,
                 )
 
                 every { storage.latestBlock() } returns genesisBlock.toStore()
@@ -177,9 +175,9 @@ class BlockchainTest : DescribeSpec({
             it("should reject block with invalid height") {
                 val storage = mockk<Storage>()
                 val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
-                val badBlock = randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val badBlock = randomBlock("", 0u)
 
-                every { storage.latestBlock() } returns randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore()
+                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
                 every { storage.chainSize() } returns 1
                 blockchain.processBlock(badBlock) shouldBe false
             }
@@ -187,9 +185,9 @@ class BlockchainTest : DescribeSpec({
             it("should reject block without matching previousHash") {
                 val storage = mockk<Storage>()
                 val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
-                val badBlock = randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val badBlock = randomBlock("", 1u)
 
-                every { storage.latestBlock() } returns randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore()
+                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
                 every { storage.chainSize() } returns 0
 
                 blockchain.processBlock(badBlock) shouldBe false
@@ -199,7 +197,7 @@ class BlockchainTest : DescribeSpec({
                 val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                 val storage = mockk<Storage>()
                 val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
-                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
 
                 every { storage.latestBlock() } returns genesisBlock.toStore()
                 every { storage.chainSize() } returns 1
@@ -210,7 +208,7 @@ class BlockchainTest : DescribeSpec({
                 every { storage.latestBlock() } returns goodBlock.toStore()
                 every { storage.chainSize() } returns 2
 
-                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp - 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp - 1)
                 blockchain.processBlock(badBlock) shouldBe false
 
                 verify(exactly = 1) { storage.storeBlock(any()) }
@@ -220,7 +218,7 @@ class BlockchainTest : DescribeSpec({
                 val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                 val storage = mockk<Storage>()
                 val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
-                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
 
                 every { storage.latestBlock() } returns genesisBlock.toStore()
                 every { storage.chainSize() } returns 1
@@ -231,7 +229,7 @@ class BlockchainTest : DescribeSpec({
                 every { storage.latestBlock() } returns goodBlock.toStore()
                 every { storage.chainSize() } returns 2
 
-                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey, signature = "invalid")
+                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp + 1, signature = "invalid")
                 blockchain.processBlock(badBlock) shouldBe false
 
                 verify(exactly = 1) { storage.storeBlock(any()) }
@@ -257,11 +255,9 @@ fun randomBlock(
     data: TransactionData = TransactionData(
         emptyList(), emptySet()
     ),
-    publisherKey: String = "",
-    publisherSigningKey: String = "",
     signature: String? = null,
 ) = Block(
-    publisherKey = publisherKey,
+    publisherKey = publisherPublicKey,
     signature = signature ?: sign(publisherSigningKey.toPrivateKey(), previousHash + data + timestamp + height).toHexString(),
     previousHash = previousHash,
     data = data,

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.string.shouldBeEmpty
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.avisen.crypto.toPrivateKey
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
@@ -23,13 +24,16 @@ import java.time.LocalDate
 class BlockchainTest : DescribeSpec({
     setupSecurity()
 
+    val publisherPublicKey = "MEkwEwYHKoZIzj0CAQYIKoZIzj0DAQEDMgAEje4IzKZB+pqvn5iT9QLgX97HtigQYQ6D5BXVWh8vBfvGPCzDtmSOhsji753dPciU"
+    val publisherSigningKey = "MHsCAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQEEYTBfAgEBBBitZRQG15sGSSyBKRBZ96XDkx+t03p3P4ugCgYIKoZIzj0DAQGhNAMyAASN7gjMpkH6mq+fmJP1AuBf3se2KBBhDoPkFdVaHy8F+8Y8LMO2ZI6GyOLvnd09yJQ="
+
     describe("Blockchain") {
         describe("getBlock") {
             it("should return a Block if found") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
 
-                val randomBlock = randomBlock("", 1u)
+                val randomBlock = randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
                 every { storage.getBlock(any()) } returns randomBlock.toStore()
 
                 blockchain.getBlock(randomBlock.hash) shouldBe randomBlock
@@ -39,19 +43,19 @@ class BlockchainTest : DescribeSpec({
         describe("chain") {
             it("should return a list of 10 blocks") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
 
                 every { storage.blocks(any(), any(), any()) } returns listOf(
-                    Block.genesis().toStore(),
-                    randomBlock("", 1u).toStore(),
-                    randomBlock("", 2u).toStore(),
-                    randomBlock("", 3u).toStore(),
-                    randomBlock("", 4u).toStore(),
-                    randomBlock("", 5u).toStore(),
-                    randomBlock("", 6u).toStore(),
-                    randomBlock("", 7u).toStore(),
-                    randomBlock("", 8u).toStore(),
-                    randomBlock("", 9u).toStore(),
+                    Block.genesis(publisherPublicKey, publisherSigningKey).toStore(),
+                    randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 2u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 3u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 4u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 5u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 6u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 7u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 8u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 9u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
                 )
 
                 blockchain.chain(0, null, null, null) shouldHaveSize 10
@@ -59,22 +63,22 @@ class BlockchainTest : DescribeSpec({
 
             it("should return a list of 5 blocks when size of 5 is selected") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
 
                 every { storage.blocks(0, any(), any()) } returns listOf(
-                    Block.genesis().toStore(),
-                    randomBlock("", 1u).toStore(),
-                    randomBlock("", 2u).toStore(),
-                    randomBlock("", 3u).toStore(),
-                    randomBlock("", 4u).toStore(),
+                    Block.genesis(publisherPublicKey, publisherSigningKey).toStore(),
+                    randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 2u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 3u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 4u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
                 )
 
                 every { storage.blocks(1, any(), any()) } returns listOf(
-                    randomBlock("", 5u).toStore(),
-                    randomBlock("", 6u).toStore(),
-                    randomBlock("", 7u).toStore(),
-                    randomBlock("", 8u).toStore(),
-                    randomBlock("", 9u).toStore(),
+                    randomBlock("", 5u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 6u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 7u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 8u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
+                    randomBlock("", 9u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore(),
                 )
 
                 blockchain.chain(0, 5, null, null) shouldHaveSize 5
@@ -86,7 +90,7 @@ class BlockchainTest : DescribeSpec({
 
             it("should accept valid article") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
                 val publisherKeyPair = generateKeyPair().shouldNotBeNull()
 
                 val goodArticle = randomArticle(publisherKeyPair)
@@ -97,9 +101,9 @@ class BlockchainTest : DescribeSpec({
 
             describe("maximum amount of articles") {
                 it("should mint new block") {
-                    val genesisBlock = Block.genesis()
+                    val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                     val storage = mockk<Storage>()
-                    val blockchain = Blockchain(storage)
+                    val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
                     val publisherKeyPair = generateKeyPair().shouldNotBeNull()
 
                     every { storage.latestBlock() } returns genesisBlock.toStore()
@@ -121,9 +125,9 @@ class BlockchainTest : DescribeSpec({
                 }
 
                 it("should add unprocessed publisher to block") {
-                    val genesisBlock = Block.genesis("test")
+                    val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                     val storage = mockk<Storage>()
-                    val blockchain = Blockchain(storage, unprocessedPublishers = mutableSetOf("test2"))
+                    val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey), unprocessedPublishers = mutableSetOf("test2"))
                     val publisherKeyPair = generateKeyPair().shouldNotBeNull()
 
                     every { storage.latestBlock() } returns genesisBlock.toStore()
@@ -149,10 +153,19 @@ class BlockchainTest : DescribeSpec({
 
         describe("processBlock") {
             it("should accept block with valid height and matching previousHash") {
-                val genesisBlock = Block.genesis()
+                val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
-                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val goodBlock = randomBlock(
+                    genesisBlock.hash,
+                    genesisBlock.height + 1u,
+                    genesisBlock.timestamp + 1,
+                    TransactionData(
+                        emptyList(), setOf(publisherPublicKey)
+                    ),
+                    publisherPublicKey,
+                    publisherSigningKey,
+                )
 
                 every { storage.latestBlock() } returns genesisBlock.toStore()
                 every { storage.chainSize() } returns 1
@@ -163,30 +176,30 @@ class BlockchainTest : DescribeSpec({
 
             it("should reject block with invalid height") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
-                val badBlock = randomBlock("", 0u)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val badBlock = randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
 
-                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
+                every { storage.latestBlock() } returns randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore()
                 every { storage.chainSize() } returns 1
                 blockchain.processBlock(badBlock) shouldBe false
             }
 
             it("should reject block without matching previousHash") {
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
-                val badBlock = randomBlock("", 1u)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val badBlock = randomBlock("", 1u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
 
-                every { storage.latestBlock() } returns randomBlock("", 0u).toStore()
+                every { storage.latestBlock() } returns randomBlock("", 0u, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey).toStore()
                 every { storage.chainSize() } returns 0
 
                 blockchain.processBlock(badBlock) shouldBe false
             }
 
             it("should reject block with timestamp in the past") {
-                val genesisBlock = Block.genesis()
+                val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage)
-                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1)
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
 
                 every { storage.latestBlock() } returns genesisBlock.toStore()
                 every { storage.chainSize() } returns 1
@@ -197,7 +210,28 @@ class BlockchainTest : DescribeSpec({
                 every { storage.latestBlock() } returns goodBlock.toStore()
                 every { storage.chainSize() } returns 2
 
-                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp - 1)
+                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp - 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+                blockchain.processBlock(badBlock) shouldBe false
+
+                verify(exactly = 1) { storage.storeBlock(any()) }
+            }
+
+            it("should reject block with invalid signature") {
+                val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val goodBlock = randomBlock(genesisBlock.hash, genesisBlock.height + 1u, genesisBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey)
+
+                every { storage.latestBlock() } returns genesisBlock.toStore()
+                every { storage.chainSize() } returns 1
+                every { storage.storeBlock(any()) } returns Unit
+
+                blockchain.processBlock(goodBlock) shouldBe true
+
+                every { storage.latestBlock() } returns goodBlock.toStore()
+                every { storage.chainSize() } returns 2
+
+                val badBlock = randomBlock(goodBlock.hash, goodBlock.height + 1u, goodBlock.timestamp + 1, publisherKey = publisherPublicKey, publisherSigningKey = publisherSigningKey, signature = "invalid")
                 blockchain.processBlock(badBlock) shouldBe false
 
                 verify(exactly = 1) { storage.storeBlock(any()) }
@@ -207,18 +241,30 @@ class BlockchainTest : DescribeSpec({
 
     describe("genesisBlock") {
         it("should have no previous hash and 0 height") {
-            val genesisBlock = Block.genesis()
+            val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
 
             genesisBlock.previousHash.shouldBeEmpty()
             genesisBlock.height shouldBe 0u
-            genesisBlock.data shouldBe TransactionData(emptyList(), setOf(""))
+            genesisBlock.data shouldBe TransactionData(emptyList(), setOf(publisherPublicKey))
         }
     }
 })
 
-fun randomBlock(previousHash: String, height: UInt, timestamp: Long = Instant.now().toEpochMilli()) = Block(
+fun randomBlock(
+    previousHash: String,
+    height: UInt,
+    timestamp: Long = Instant.now().toEpochMilli(),
+    data: TransactionData = TransactionData(
+        emptyList(), emptySet()
+    ),
+    publisherKey: String = "",
+    publisherSigningKey: String = "",
+    signature: String? = null,
+) = Block(
+    publisherKey = publisherKey,
+    signature = signature ?: sign(publisherSigningKey.toPrivateKey(), previousHash + data + timestamp + height).toHexString(),
     previousHash = previousHash,
-    data = TransactionData(emptyList(), emptySet()),
+    data = data,
     timestamp = timestamp,
     height = height,
 )

--- a/crypto/src/main/kotlin/org/avisen/crypto/Crypto.kt
+++ b/crypto/src/main/kotlin/org/avisen/crypto/Crypto.kt
@@ -79,7 +79,7 @@ fun verifySignature(publicKey: PublicKey?, data: String, signature: ByteArray?):
         ecdsaVerify.update(data.toByteArray())
         return ecdsaVerify.verify(signature)
     } catch (e: java.lang.Exception) {
-        throw RuntimeException(e)
+        return false
     }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -730,6 +730,11 @@
     }
   }
 };
+            defs["Publisher"] = {
+  "properties" : {
+    "publicKey" : { }
+  }
+};
             defs["Signature"] = {
   "properties" : {
     "signature" : { }
@@ -775,6 +780,9 @@
                     </li>
                     <li data-group="Default" data-name="networkNodePost" class="">
                       <a href="#api-Default-networkNodePost">networkNodePost</a>
+                    </li>
+                    <li data-group="Default" data-name="networkNodePublisherPost" class="">
+                      <a href="#api-Default-networkNodePublisherPost">networkNodePublisherPost</a>
                     </li>
                     <li data-group="Default" data-name="statusGet" class="">
                       <a href="#api-Default-statusGet">statusGet</a>
@@ -2558,6 +2566,267 @@ except ApiException as e:
 
                           <h2>Responses</h2>
                             <h3> Status: 201 - Created </h3>
+
+                            <ul class="nav nav-tabs nav-tabs-examples" >
+                            </ul>
+
+                            <div class="tab-content" style='margin-bottom: 10px;'>
+                            </div>
+
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-networkNodePublisherPost">
+                      <article id="api-Default-networkNodePublisherPost-0" data-group="User" data-name="networkNodePublisherPost" data-version="0">
+                        <div class="pull-left">
+                          <h1>networkNodePublisherPost</h1>
+                          <p>Add a publisher</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Adds a publisher to the block&#x27;s list of unprocessed publishers. Once a block is minted, the publisher can mint its own blocks.</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/network/node/publisher</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-networkNodePublisherPost-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-networkNodePublisherPost-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-networkNodePublisherPost-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-networkNodePublisherPost-0-python">Python</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-networkNodePublisherPost-0-curl">
+                           <pre class="prettyprint"><code class="language-bsh">curl -X POST\
+-H "Content-Type: application/json"\
+"//network/node/publisher"</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-java">
+                            <pre class="prettyprint"><code class="language-java">import io.swagger.client.*;
+import io.swagger.client.auth.*;
+import io.swagger.client.model.*;
+import io.swagger.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+
+    public static void main(String[] args) {
+        
+        DefaultApi apiInstance = new DefaultApi();
+        Publisher body = ; // Publisher | 
+        try {
+            apiInstance.networkNodePublisherPost(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#networkNodePublisherPost");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-android">
+                            <pre class="prettyprint"><code class="language-java">import io.swagger.client.api.DefaultApi;
+
+public class DefaultApiExample {
+
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        Publisher body = ; // Publisher | 
+        try {
+            apiInstance.networkNodePublisherPost(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#networkNodePublisherPost");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Publisher *body = ; // 
+
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+
+// Add a publisher
+[apiInstance networkNodePublisherPostWith:body
+              completionHandler: ^(NSError* error) {
+                            if (error) {
+                                NSLog(@"Error: %@", error);
+                            }
+                        }];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var Avisen = require('avisen');
+
+var api = new Avisen.DefaultApi()
+var body = ; // {{Publisher}} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.networkNodePublisherPost(body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using IO.Swagger.Api;
+using IO.Swagger.Client;
+using IO.Swagger.Model;
+
+namespace Example
+{
+    public class networkNodePublisherPostExample
+    {
+        public void main()
+        {
+
+            var apiInstance = new DefaultApi();
+            var body = new Publisher(); // Publisher | 
+
+            try
+            {
+                // Add a publisher
+                apiInstance.networkNodePublisherPost(body);
+            }
+            catch (Exception e)
+            {
+                Debug.Print("Exception when calling DefaultApi.networkNodePublisherPost: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+$api_instance = new Swagger\Client\ApiDefaultApi();
+$body = ; // Publisher | 
+
+try {
+    $api_instance->networkNodePublisherPost($body);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->networkNodePublisherPost: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::SwaggerClient::Configuration;
+use WWW::SwaggerClient::DefaultApi;
+
+my $api_instance = WWW::SwaggerClient::DefaultApi->new();
+my $body = WWW::SwaggerClient::Object::Publisher->new(); # Publisher | 
+
+eval { 
+    $api_instance->networkNodePublisherPost(body => $body);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->networkNodePublisherPost: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-networkNodePublisherPost-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import swagger_client
+from swagger_client.rest import ApiException
+from pprint import pprint
+
+# create an instance of the API class
+api_instance = swagger_client.DefaultApi()
+body =  # Publisher | 
+
+try: 
+    # Add a publisher
+    api_instance.network_node_publisher_post(body)
+except ApiException as e:
+    print("Exception when calling DefaultApi->networkNodePublisherPost: %s\n" % e)</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+                                <td>
+                                
+                                
+                                <script>
+                                $(document).ready(function() {
+                                  var schemaWrapper = {
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Publisher"
+      }
+    }
+  },
+  "required" : true
+};
+                                  var schema = schemaWrapper.content["application/json"].schema;
+                                  if (schema.$ref != null) {
+                                    schema = defsParser.$refs.get(schema.$ref);
+                                  } else {
+                                    schemaWrapper.components = {};
+                                    schemaWrapper.components.schemas = Object.assign({}, defs);
+                                    $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                      console.log(err);
+                                    });
+                                  }
+                                
+                                  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+                                  var result = $('#d2e199_networkNodePublisherPost_body');
+                                  result.empty();
+                                  result.append(view.render());
+                                });
+                                </script>
+                                <div id="d2e199_networkNodePublisherPost_body"></div>
+                                </td>
+                                </tr>
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3> Status: 200 - Ok </h3>
 
                             <ul class="nav nav-tabs nav-tabs-examples" >
                             </ul>

--- a/network/src/main/kotlin/org/avisen/network/Network.kt
+++ b/network/src/main/kotlin/org/avisen/network/Network.kt
@@ -53,6 +53,11 @@ data class NodeInfo(
 }
 
 @Serializable
+data class Publisher(
+    val publicKey: String,
+)
+
+@Serializable
 data class Network(
     @Transient private val client: NetworkClient = NetworkWebClient(""),
     private val peers: MutableList<Node> = mutableListOf(),

--- a/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
+++ b/network/src/test/kotlin/org/avisen/network/NetworkTest.kt
@@ -60,7 +60,7 @@ class NetworkTest: DescribeSpec({
                 network.addPeer(Node("first", NodeType.REPLICA), false)
                 network.addPeer(Node("second", NodeType.REPLICA), false)
 
-                network.broadcastBlock(Block("prevHash", TransactionData(emptyList(), emptySet()), Instant.now().toEpochMilli(), 1u))
+                network.broadcastBlock(Block("pubKey", "signature", "prevHash", TransactionData(emptyList(), emptySet()), Instant.now().toEpochMilli(), 1u))
 
                 coVerify(exactly = 2) { networkClient.broadcastBlock(any(), any()) }
             }

--- a/sql/src/main/kotlin/org/avisen/sql/Db.kt
+++ b/sql/src/main/kotlin/org/avisen/sql/Db.kt
@@ -23,6 +23,8 @@ class Db(private val database: Database): Storage {
     override fun storeBlock(block: StoreBlock) {
         transaction(database) {
             Blocks.insert {
+                it[publisherKey] = block.publisherKey
+                it[signature] = block.signature
                 it[hash] = block.hash
                 it[previousHash] = block.previousHash
                 it[data] = block.data
@@ -36,6 +38,8 @@ class Db(private val database: Database): Storage {
     override fun getBlock(hash: String): StoreBlock? = transaction(database) {
         Blocks.selectAll().where { Blocks.hash eq hash }.singleOrNull()?.let {
             StoreBlock(
+                it[Blocks.publisherKey],
+                it[Blocks.signature],
                 it[Blocks.hash],
                 it[Blocks.previousHash],
                 it[Blocks.data],
@@ -51,6 +55,8 @@ class Db(private val database: Database): Storage {
            .orderBy(Blocks.height to SortOrder.DESC)
            .firstOrNull()?.let {
                StoreBlock(
+                   it[Blocks.publisherKey],
+                   it[Blocks.signature],
                    it[Blocks.hash],
                    it[Blocks.previousHash],
                    it[Blocks.data],
@@ -74,6 +80,8 @@ class Db(private val database: Database): Storage {
             .offset((page * size).toLong())
             .map {
                 StoreBlock(
+                    it[Blocks.publisherKey],
+                    it[Blocks.signature],
                     it[Blocks.hash],
                     it[Blocks.previousHash],
                     it[Blocks.data],
@@ -92,6 +100,8 @@ class Db(private val database: Database): Storage {
             .offset((10 * page).toLong())
             .map {
                 StoreBlock(
+                    it[Blocks.publisherKey],
+                    it[Blocks.signature],
                     it[Blocks.hash],
                     it[Blocks.previousHash],
                     it[Blocks.data],
@@ -139,6 +149,8 @@ class Db(private val database: Database): Storage {
 val format = Json { prettyPrint = false }
 
 object Blocks : UIntIdTable("block") {
+    val publisherKey: Column<String> = varchar("publisher_key", 100)
+    val signature: Column<String> = varchar("signature", 76)
     val hash: Column<String> = varchar("hash", 64)
     val previousHash: Column<String> = varchar("previous_hash", 64)
     val data: Column<StoreTransactionData> = jsonb("data", format)

--- a/sql/src/main/resources/db/migration/V20250222081742__init.sql
+++ b/sql/src/main/resources/db/migration/V20250222081742__init.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS block (
     hash VARCHAR(64) NOT NULL,
     previous_hash VARCHAR(64) NOT NULL,
     data jsonb NOT NULL,
+    publisher_key VARCHAR(100) NOT NULL,
+    signature VARCHAR(76) NOT NULL,
     timestamp BIGINT NOT NULL,
     height BIGINT NOT NULL,
     create_date TIMESTAMP NOT NULL

--- a/storage/src/main/kotlin/org/avisen/storage/Storage.kt
+++ b/storage/src/main/kotlin/org/avisen/storage/Storage.kt
@@ -15,6 +15,8 @@ interface Storage {
 }
 
 data class StoreBlock(
+    val publisherKey: String,
+    val signature: String,
     val hash: String,
     val previousHash: String,
     val data: StoreTransactionData,


### PR DESCRIPTION
Changes
* Changed `Article.publisherKey` to `Article.authorId` so as not to confuse it with `Block.publisherKey`
* Blocks are now signed using the node's `PUBLISHER_SIGNING_KEY`.
* Blocks are now checked to make sure their publisher exists in the previous latest `block.data.publishers`
* Block signatures are now verified
* New publishers can be onboarded using an api endpoint