### PR TITLE
Store publisher as object

### DIFF
--- a/app/src/main/kotlin/org/avisen/app/App.kt
+++ b/app/src/main/kotlin/org/avisen/app/App.kt
@@ -38,7 +38,8 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import org.avisen.network.Publisher
+import org.avisen.blockchain.Publisher
+import org.avisen.network.NewPublisher
 
 fun main(args: Array<String>): Unit = io.ktor.server.netty.EngineMain.main(args)
 
@@ -212,9 +213,9 @@ fun Application.module() {
                     if (nodeInfo.type == NodeType.PUBLISHER) {
                         route("/publisher") {
                             post {
-                                val newPublisher = call.receive<Publisher>()
+                                val newPublisher = call.receive<NewPublisher>()
 
-                                val result = blockchain.acceptPublisher(newPublisher.publicKey, newPublisher.signature)
+                                val result = blockchain.acceptPublisher(Publisher(newPublisher.publicKey), newPublisher.signature)
 
                                 if (result) {
                                    call.response.status(HttpStatusCode.OK)

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -127,7 +127,7 @@ class BlockchainTest : DescribeSpec({
                 it("should add unprocessed publisher to block") {
                     val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
                     val storage = mockk<Storage>()
-                    val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey), unprocessedPublishers = mutableSetOf("test2"))
+                    val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey), unprocessedPublishers = mutableSetOf(Publisher("test2")))
                     val publisherKeyPair = generateKeyPair().shouldNotBeNull()
 
                     every { storage.latestBlock() } returns genesisBlock.toStore()
@@ -160,7 +160,7 @@ class BlockchainTest : DescribeSpec({
                 val publicKey = keysToAdd.second.getString()
                 val signature = sign(publisherSigningKey.toPrivateKey(), publicKey)
 
-                blockchain.acceptPublisher(publicKey, signature.toHexString()) shouldBe true
+                blockchain.acceptPublisher(Publisher(publicKey), signature.toHexString()) shouldBe true
             }
 
             it("should not accept publisher with invalid signature") {
@@ -171,7 +171,7 @@ class BlockchainTest : DescribeSpec({
                 val publicKey = keysToAdd.second.getString()
                 val signature = sign(keysToAdd.first, "invalid")
 
-                blockchain.acceptPublisher(publicKey, signature.toHexString()) shouldBe false
+                blockchain.acceptPublisher(Publisher(publicKey), signature.toHexString()) shouldBe false
             }
 
             it("should not add duplicate publisher") {
@@ -179,11 +179,11 @@ class BlockchainTest : DescribeSpec({
                 val publicKey = keysToAdd.second.getString()
 
                 val storage = mockk<Storage>()
-                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey), unprocessedPublishers = mutableSetOf(publicKey))
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey), unprocessedPublishers = mutableSetOf(Publisher(publicKey)))
 
                 val signature = sign(keysToAdd.first, publicKey)
 
-                blockchain.acceptPublisher(publicKey, signature.toHexString()) shouldBe false
+                blockchain.acceptPublisher(Publisher(publicKey), signature.toHexString()) shouldBe false
             }
         }
 
@@ -197,7 +197,7 @@ class BlockchainTest : DescribeSpec({
                     genesisBlock.height + 1u,
                     genesisBlock.timestamp + 1,
                     TransactionData(
-                        emptyList(), setOf(publisherPublicKey)
+                        emptyList(), setOf(Publisher(publisherPublicKey))
                     ),
                 )
 
@@ -279,7 +279,7 @@ class BlockchainTest : DescribeSpec({
 
             genesisBlock.previousHash.shouldBeEmpty()
             genesisBlock.height shouldBe 0u
-            genesisBlock.data shouldBe TransactionData(emptyList(), setOf(publisherPublicKey))
+            genesisBlock.data shouldBe TransactionData(emptyList(), setOf(Publisher(publisherPublicKey)))
         }
     }
 })

--- a/docs/index.html
+++ b/docs/index.html
@@ -726,7 +726,7 @@
   "properties" : {
     "address" : { },
     "type" : {
-      "enum" : [ "PUBLISHER", "REPLICA", null ]
+      "enum" : [ "PUBLISHER", "REPLICA" ]
     }
   }
 };

--- a/network/src/main/kotlin/org/avisen/network/Network.kt
+++ b/network/src/main/kotlin/org/avisen/network/Network.kt
@@ -53,7 +53,7 @@ data class NodeInfo(
 }
 
 @Serializable
-data class Publisher(
+data class NewPublisher(
     val publicKey: String,
     val signature: String,
 )

--- a/storage/src/main/kotlin/org/avisen/storage/Storage.kt
+++ b/storage/src/main/kotlin/org/avisen/storage/Storage.kt
@@ -28,7 +28,7 @@ data class StoreBlock(
 @Serializable
 data class StoreTransactionData(
     val articles: List<StoreArticle>,
-    val publishers: Set<String>,
+    val publishers: Set<StorePublisher>,
 )
 
 @Serializable
@@ -41,4 +41,9 @@ data class StoreArticle (
     val content: String,
     val date: String,
     val signature: String,
+)
+
+@Serializable
+data class StorePublisher(
+    val publicKey: String,
 )


### PR DESCRIPTION
Changes
* Publishers are now stored in storage as an object so they are future-proof if we need to store more information about a publisher (like its name, perhaps)
* This is a breaking change so dbs in the `testnet` will need to be reset before deploying with this version