### PR TITLE
Accept content

### DIFF
--- a/app/src/main/resources/openapi/documentation.yml
+++ b/app/src/main/resources/openapi/documentation.yml
@@ -267,6 +267,10 @@ components:
           type: string
         content:
           type: string
+          minLength: 1
+          maxLength: 7500
+        contentHash:
+          type: string
         date:
           type: string
           format: date

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -97,7 +97,9 @@ class BlockchainTest : DescribeSpec({
                 val goodArticle = randomArticle(publisherKeyPair)
 
                 // Adding one article should not create a block
-                blockchain.processArticle(goodArticle).processed shouldBe true
+                val processedArticle = blockchain.processArticle(goodArticle)
+                processedArticle.processed shouldBe true
+                processedArticle.block.shouldBeNull()
             }
 
             it("should not accept article with invalid content hash") {
@@ -334,7 +336,7 @@ fun randomArticle(publisherKeyPair: Pair<PrivateKey, PublicKey>): Article {
     val contentHash = hash(content)
     val date = LocalDate.now().toString()
 
-    val signature = sign(publisherKeyPair.first, byline + headline +section + contentHash + date)
+    val signature = sign(publisherKeyPair.first, byline + headline + section + content + contentHash + date)
 
     return Article(
         authorKey = publisherKeyPair.second.getString(),

--- a/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
+++ b/blockchain/src/test/kotlin/org/avisen/blockchain/BlockchainTest.kt
@@ -100,6 +100,30 @@ class BlockchainTest : DescribeSpec({
                 blockchain.processArticle(goodArticle).processed shouldBe true
             }
 
+            it("should not accept article with invalid content hash") {
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val publisherKeyPair = generateKeyPair().shouldNotBeNull()
+
+                val badArticle = randomArticle(publisherKeyPair).copy(contentHash = "invalid")
+
+                blockchain.processArticle(badArticle).processed shouldBe false
+            }
+
+            it("should not accept article with invalid content length") {
+                val storage = mockk<Storage>()
+                val blockchain = Blockchain(storage, Pair(publisherSigningKey, publisherPublicKey))
+                val publisherKeyPair = generateKeyPair().shouldNotBeNull()
+
+                val articleWithNoContent = randomArticle(publisherKeyPair).copy(content = "")
+
+                blockchain.processArticle(articleWithNoContent).processed shouldBe false
+
+                val articleWithTooLongContent = randomArticle(publisherKeyPair).copy(content = buildString { repeat(751) { append("abcdefghij")} })
+
+                blockchain.processArticle(articleWithTooLongContent).processed shouldBe false
+            }
+
             describe("maximum amount of articles") {
                 it("should mint new block") {
                     val genesisBlock = Block.genesis(publisherPublicKey, publisherSigningKey)
@@ -306,10 +330,11 @@ fun randomArticle(publisherKeyPair: Pair<PrivateKey, PublicKey>): Article {
     val byline = "byline"
     val headline = "headline"
     val section = "section"
-    val content = hash("content")
+    val content = "content"
+    val contentHash = hash(content)
     val date = LocalDate.now().toString()
 
-    val signature = sign(publisherKeyPair.first, byline + headline +section + content + date)
+    val signature = sign(publisherKeyPair.first, byline + headline +section + contentHash + date)
 
     return Article(
         authorKey = publisherKeyPair.second.getString(),
@@ -317,6 +342,7 @@ fun randomArticle(publisherKeyPair: Pair<PrivateKey, PublicKey>): Article {
         headline,
         section,
         content,
+        contentHash,
         date,
         signature.toHexString(),
     )

--- a/docs/index.html
+++ b/docs/index.html
@@ -695,7 +695,11 @@
     "byline" : { },
     "headline" : { },
     "section" : { },
-    "content" : { },
+    "content" : {
+      "maxLength" : 7500,
+      "minLength" : 1
+    },
+    "contentHash" : { },
     "date" : {
       "format" : "date"
     },

--- a/storage/src/main/kotlin/org/avisen/storage/Storage.kt
+++ b/storage/src/main/kotlin/org/avisen/storage/Storage.kt
@@ -38,6 +38,7 @@ data class StoreArticle (
     val byline: String,
     val headline: String,
     val section: String,
+    val content: String? = null,
     val contentHash: String,
     val date: String,
     val signature: String,


### PR DESCRIPTION
Adding the ability for full articles (with maximum size of 7500 characters) to be optionally uploaded to the blockchain. This is better security for content that is not paywalled.